### PR TITLE
Use router.emit instead of Engine.emit

### DIFF
--- a/lib/fluent/plugin/out_elapsed_time.rb
+++ b/lib/fluent/plugin/out_elapsed_time.rb
@@ -7,6 +7,11 @@ module Fluent
       define_method("log") { $log }
     end
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :tag, :string, :default => 'elapsed'
     config_param :add_tag_prefix, :string, :default => nil
     config_param :remove_tag_prefix, :string, :default => nil
@@ -143,7 +148,7 @@ module Fluent
         avg = num == 0 ? 0 : elapsed.map(&:to_f).inject(:+) / num.to_f
         messages[tag] = {"max" => max, "avg" => avg, "num" => num}
       end
-      messages.each {|tag, message| Engine.emit(tag, Engine.now, message) }
+      messages.each {|tag, message| router.emit(tag, Engine.now, message) }
     end
 
     private


### PR DESCRIPTION
In Fluentd v0.14, plugins have to use `router.emit` instead of `Engine.emit`.

Otherwise, I got the following errors:

```log
Failures:

  1) Fluent::ElapsedTimeOutput test emit each es with aggregate tag should == 4
     Failure/Error: messages.each {|tag, message| Engine.emit(tag, Engine.now, message) }
     
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./vendor/bundle/ruby/2.3.0/bundler/gems/fluentd-d5476d747846/lib/fluent/engine.rb:132:in `emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `block in flush_emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `each'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `flush_emit'
     # ./spec/out_elapsed_time_spec.rb:106:in `block (4 levels) in <top (required)>'

  2) Fluent::ElapsedTimeOutput test emit zero_emit true 
     Failure/Error: messages.each {|tag, message| Engine.emit(tag, Engine.now, message) }
     
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./vendor/bundle/ruby/2.3.0/bundler/gems/fluentd-d5476d747846/lib/fluent/engine.rb:132:in `emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `block in flush_emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `each'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `flush_emit'
     # ./spec/out_elapsed_time_spec.rb:129:in `block (4 levels) in <top (required)>'

  3) Fluent::ElapsedTimeOutput test emit zero_emit false 
     Failure/Error: messages.each {|tag, message| Engine.emit(tag, Engine.now, message) }
     
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./vendor/bundle/ruby/2.3.0/bundler/gems/fluentd-d5476d747846/lib/fluent/engine.rb:132:in `emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `block in flush_emit'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `each'
     # ./lib/fluent/plugin/out_elapsed_time.rb:146:in `flush_emit'
     # ./spec/out_elapsed_time_spec.rb:141:in `block (4 levels) in <top (required)>'
```